### PR TITLE
Refactor setup.sh script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,38 +2,63 @@
 
 # Install script for rofi themes
 
+# Debug options
+# See: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+# set -euxo pipefail
+
 # Dirs
-DIR=`pwd`
-FONT_DIR="$HOME/.local/share/fonts"
+DIR="$(cd "$(dirname "$0")" || exit 1; pwd -P)"
+FONTS_DIR="$HOME/.local/share/fonts"
 ROFI_DIR="$HOME/.config/rofi"
 
 # Install Fonts
 install_fonts() {
-	echo -e "\n[*] Installing fonts..."
-	if [[ -d "$FONT_DIR" ]]; then
-		cp -rf $DIR/fonts/* "$FONT_DIR"
-	else
-		mkdir -p "$FONT_DIR"
-		cp -rf $DIR/fonts/* "$FONT_DIR"
+	printf "%s\n" "[*] Installing Fonts..."
+	if [[ ! -d "$FONTS_DIR" ]]; then
+		mkdir -p "$FONTS_DIR"
 	fi
+	cp -rf "$DIR"/fonts/* "$FONTS_DIR"
+
+	# Regenerate font cache files
+	if [[ $(command -v fc-cache) ]]; then
+		fc-cache
+	fi
+}
+
+# Initialize a repo with the files copied
+init_git_repository() {
+	# Do not attempt to initialize the repository if git is not configured
+	if [[ ! $(git config user.name || git config user.email) ]]; then
+		return 1
+	fi
+
+	printf "%s\n" "[*] Initializing Repository..."
+
+	cd "$ROFI_DIR" || return 1
+	git init -q && git add . && git commit -m "Initial commit" \
+		-m "Source: https://github.com/adi1090x/rofi" > /dev/null
 }
 
 # Install Themes
 install_themes() {
 	if [[ -d "$ROFI_DIR" ]]; then
-		echo -e "[*] Creating a backup of your rofi configs..."
+		printf "%s\n" "[*] Creating a backup of your rofi config..."
 		mv "$ROFI_DIR" "${ROFI_DIR}.old"
-		{ mkdir -p "$ROFI_DIR"; cp -rf $DIR/$RES/* "$ROFI_DIR"; }
-	else
-		{ mkdir -p "$ROFI_DIR"; cp -rf $DIR/$RES/* "$ROFI_DIR"; }	
 	fi
-	if [[ -f "$ROFI_DIR/config.rasi" ]]; then
-		echo -e "[*] Successfully Installed.\n"
-		exit 0
-	else
-		echo -e "[!] Failed to install.\n"
-		exit 1
+
+	mkdir -p "$ROFI_DIR"
+	cp -rf "$DIR/$RES"/* "$ROFI_DIR"
+
+	if [[ ! -f "$ROFI_DIR/config.rasi" ]]; then
+		printf "%s\n" "[!] Failed to install."
+		return 1
 	fi
+
+	# Check if git is installed
+	[[ $(command -v git) ]] && init_git_repository
+
+	printf "%s\n" "[*] Successfully Installed."
+	return 0
 }
 
 # Main
@@ -41,27 +66,32 @@ main() {
 	clear
 	cat <<- EOF
 		[*] Installing Rofi Themes...
-		
+
 		[*] Choose your screen resolution -
 		[1] 1920x1080
 		[2] 1366x768
-	
+
 	EOF
 
-	read -p "[?] Select Option : "
+	# shellcheck disable=SC2162
+	read -p "[?] Select Option: "
 
 	if [[ $REPLY == "1" ]]; then
-		RES='1080p'
-		install_fonts
-		install_themes
+		RES="1080p"
 	elif [[ $REPLY == "2" ]]; then
-		RES='720p'
-		install_fonts
-		install_themes
+		RES="720p"
 	else
-		echo -e "\n[!] Invalid Option, Exiting...\n"
+		printf "%s\n" "[!] Invalid Option ($REPLY), type 1 or 2. Exiting."
 		exit 1
 	fi
+
+	install_fonts
+	install_themes
+
+	# Exit code determined by the output of install_themes
+	exit $?
 }
 
 main
+
+# vim: fdm=manual tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab


### PR DESCRIPTION
- Add bash debug options
- Add ignore directive for `shellcheck` in `read` command
- Deduplicate code
- Fix `DIR` path resolution (allows to execute setup.sh from anywhere)
- Replace legacy backticked notation with `$(...)` notation
- Replace `echo` with `printf`
- Quote paths to prevent globing
- Add font cache regeneration command
- Initialize a git repository with the new files (if git is configured)
- Move `exit` command from `install_themes` to the end of `main`
